### PR TITLE
Updating the code so that it compiles and runs with opencv 3.2.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 *.exe
 *.out
 *.app
+
+bin/
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif(NOT Openni2_INCLUDE)
 
 set(Openni2_REDIST $ENV{OPENNI2_REDIST})
 if(NOT Openni2_REDIST)
-  message(FATAL_ERROR "Could not find OPENNI2_INCLUDE environment variable")
+  message(FATAL_ERROR "Could not find OPENNI2_REDIST environment variable")
 endif(NOT Openni2_REDIST)
 
 include_directories( ${Openni2_INCLUDE} )

--- a/include/mog.h
+++ b/include/mog.h
@@ -14,8 +14,8 @@ public:
     void train(std::vector<cv::Mat>& training_images , std::vector<cv::Mat> &masks);
     void test(std::vector<cv::Mat>& test_images);
     void test2(std::vector<cv::Mat>& test_images);
-    cv::EM* pos_model;
-    cv::EM* neg_model;
+    cv::Ptr<cv::ml::EM> neg_model;
+    cv::Ptr<cv::ml::EM> pos_model;
     std::vector<cv::Mat> test_result;
     std::vector<Mixture> posMixtureModels;
     std::vector<Mixture> negMixtureModels;
@@ -32,7 +32,7 @@ private:
                           const cv::Mat& mask,
                           std::vector<double> &pos_samples,
                           std::vector<double> &neg_samples );
-    void test_image(cv::Mat& img, cv::Mat& dst, cv::EM &model);
+    void test_image(cv::Mat& img, cv::Mat& dst, cv::Ptr<cv::ml::EM> model);
     void test_image2(cv::Mat& img, cv::Mat& dst);
     void compute_SkinnBinMap_4_Image( const cv::Mat &rgb, /*const cv::Mat &depth,*/ cv::Mat &result ,double threshold, bool skipInvalidDepthFLAG/*, bool printFLAG*/ );
     void compute_LogRatioMap_4_Image( const cv::Mat &rgb, /*const cv::Mat &depth,*/ cv::Mat &result/*, bool skipInvalidDepthFLAG*/);

--- a/src/mog.cpp
+++ b/src/mog.cpp
@@ -2,12 +2,21 @@
 
 MOG::MOG(){
     const cv::TermCriteria criteria(cv::TermCriteria::COUNT+cv::TermCriteria::EPS, 10, FLT_EPSILON);
-    pos_model = new cv::EM(16, cv::EM::COV_MAT_DIAGONAL, criteria);
-    neg_model = new cv::EM(16, cv::EM::COV_MAT_DIAGONAL, criteria);
+    
+    this->neg_model = cv::ml::EM::create();
+    this->pos_model = cv::ml::EM::create();
+
+    this->neg_model->setClustersNumber(16);
+    this->pos_model->setClustersNumber(16);
+
+    this->neg_model->setCovarianceMatrixType(cv::ml::EM::COV_MAT_DIAGONAL);
+    this->pos_model->setCovarianceMatrixType(cv::ml::EM::COV_MAT_DIAGONAL);
+
+    this->neg_model->setTermCriteria(criteria);
+    this->pos_model->setTermCriteria(criteria);
+    
 }
 
 MOG::~MOG(){
-    delete pos_model;
-    delete neg_model;
 }
 

--- a/src/mog_io.cpp
+++ b/src/mog_io.cpp
@@ -2,25 +2,27 @@
 
 void MOG::emToMixture(){
     // get mixture variables from the EM models
-    const cv::Mat pos_means = pos_model->get<cv::Mat>("means");
-    const cv::Mat neg_means = neg_model->get<cv::Mat>("means");
-    const cv::Mat pos_weights = pos_model->get<cv::Mat>("weights");
-    const cv::Mat neg_weights = neg_model->get<cv::Mat>("weights");
-    const std::vector<cv::Mat> pos_covs = pos_model->get< std::vector<cv::Mat> >("covs");
-    const std::vector<cv::Mat> neg_covs = neg_model->get< std::vector<cv::Mat> >("covs");
+  const cv::Mat pos_means = pos_model->getMeans();
+  const cv::Mat neg_means = neg_model->getMeans();
+  const cv::Mat pos_weights = pos_model->getWeights();
+  const cv::Mat neg_weights = neg_model->getWeights();
+  std::vector<cv::Mat> pos_covs;
+  std::vector<cv::Mat> neg_covs;
+  pos_model->getCovs(pos_covs);
+  neg_model->getCovs(neg_covs);
 
-    // resize the mixture vectors
-    posMixtureModels.resize(pos_weights.cols);
-    negMixtureModels.resize(neg_weights.cols);
-    // add the data to the mixture models
-    for(int i = 0; i < (int) pos_weights.cols; i++){
-        pos_means.row(i).copyTo(posMixtureModels[i].mean);
-        neg_means.row(i).copyTo(negMixtureModels[i].mean);
-        posMixtureModels[i].invCovariance = pos_covs[i].inv().diag().t();
-        negMixtureModels[i].invCovariance = neg_covs[i].inv().diag().t();
-        posMixtureModels[i].finalWeight = pos_weights.at<double>(i) / (pow(2*M_PI, 3.0/2.0) *  pow(cv::determinant(pos_covs[i]),0.5)) ;
-        negMixtureModels[i].finalWeight = neg_weights.at<double>(i) / (pow(2*M_PI, 3.0/2.0) *  pow(cv::determinant(neg_covs[i]),0.5)) ;
-    }
+  // resize the mixture vectors
+  posMixtureModels.resize(pos_weights.cols);
+  negMixtureModels.resize(neg_weights.cols);
+  // add the data to the mixture models
+  for(int i = 0; i < (int) pos_weights.cols; i++){
+    pos_means.row(i).copyTo(posMixtureModels[i].mean);
+    neg_means.row(i).copyTo(negMixtureModels[i].mean);
+    posMixtureModels[i].invCovariance = pos_covs[i].inv().diag().t();
+    negMixtureModels[i].invCovariance = neg_covs[i].inv().diag().t();
+    posMixtureModels[i].finalWeight = pos_weights.at<double>(i) / (pow(2*M_PI, 3.0/2.0) *  pow(cv::determinant(pos_covs[i]),0.5)) ;
+    negMixtureModels[i].finalWeight = neg_weights.at<double>(i) / (pow(2*M_PI, 3.0/2.0) *  pow(cv::determinant(neg_covs[i]),0.5)) ;
+  }
 
 
 }

--- a/src/mog_test.cpp
+++ b/src/mog_test.cpp
@@ -71,8 +71,8 @@ void MOG::test2( std::vector<cv::Mat>& test_images ){
     test_result.clear();
     for (int i = 0; i < test_images.size(); i++){
         cv::Mat res_pos, res_neg, res;
-        test_image(test_images[i], res_pos, *pos_model);
-        test_image(test_images[i], res_neg, *neg_model);
+        test_image(test_images[i], res_pos, pos_model);
+        test_image(test_images[i], res_neg, neg_model);
 //        res = res_pos / (res_pos + res_neg);
         cv::log(res_pos / (1e-10+res_neg), res);
         cv::normalize(res, res, 0, 255, CV_MINMAX, CV_8UC1);
@@ -80,22 +80,22 @@ void MOG::test2( std::vector<cv::Mat>& test_images ){
     }
 }
 
-void MOG::test_image(cv::Mat &img, cv::Mat &dst, cv::EM& model){
-    dst.create( img.size(), CV_64FC1 );
+void MOG::test_image(cv::Mat &img, cv::Mat &dst, cv::Ptr<cv::ml::EM> model){
+  dst.create( img.size(), CV_64FC1 );
 
-    cv::Mat_<double> sample(1, img.channels(), CV_64FC1); // 1x3 mat
+  cv::Mat_<double> sample(1, img.channels(), CV_64FC1); // 1x3 mat
 
-    for     (int yyy=0; yyy<img.rows; yyy++)
-    {   for (int xxx=0; xxx<img.cols; xxx++)
-        {
-            // 3 channel pixel to 1x3 mat
-            sample(0) = img.at<cv::Vec3b>(yyy,xxx)(0);
-            sample(1) = img.at<cv::Vec3b>(yyy,xxx)(1);
-            sample(2) = img.at<cv::Vec3b>(yyy,xxx)(2);
+  for     (int yyy=0; yyy<img.rows; yyy++)
+  {   for (int xxx=0; xxx<img.cols; xxx++)
+    {
+      // 3 channel pixel to 1x3 mat
+      sample(0) = img.at<cv::Vec3b>(yyy,xxx)(0);
+      sample(1) = img.at<cv::Vec3b>(yyy,xxx)(1);
+      sample(2) = img.at<cv::Vec3b>(yyy,xxx)(2);
 
-            // returns a 2-element double vector, we use just
-            // the 1st element (likelihood logarithm value)
-            dst.at<double>(yyy,xxx) = std::exp(model.predict( sample )[0]);
-        }
+      // returns a 2-element double vector, we use just
+      // the 1st element (likelihood logarithm value)
+      dst.at<double>(yyy,xxx) = std::exp(model->predict( sample ));
     }
+  }
 }

--- a/src/mog_train.cpp
+++ b/src/mog_train.cpp
@@ -11,8 +11,8 @@ void MOG::train( std::vector<cv::Mat>& training_images, std::vector<cv::Mat>& ma
 
     std::cout << "Training the models, this may take a while" << std::endl;
     // train the models
-    pos_model->train( pos_samples );
-    neg_model->train( neg_samples );
+    pos_model->trainEM( pos_samples );
+    neg_model->trainEM( neg_samples );
 
     emToMixture();
     std::cout << "Finished training the models" << std::endl;


### PR DESCRIPTION
This solves #1. I only fixed the usages of `em::EM`. The proper class in OpenCV 3.2.0+ is `em::ml::EM` [(opencv reference).](https://docs.opencv.org/3.2.0/d1/dfb/classcv_1_1ml_1_1EM.html) With the this, however, come several other issues with the usage but they are minor. The project now compiles with OpenCV 3.2.0+.